### PR TITLE
Fix missing crt section

### DIFF
--- a/templates/etc/haproxy/frontend.cfg.j2
+++ b/templates/etc/haproxy/frontend.cfg.j2
@@ -4,7 +4,7 @@ frontend {{ frontend.name }}
   description {{ frontend.description }}
 {% endif %}
 
-  bind {{ frontend.bind }}{% if frontend.ssl is defined %} ssl{% for ssl in frontend.ssl %} crt {% endfor %}{% endif %}
+  bind {{ frontend.bind }}{% if frontend.ssl is defined %} ssl{% for ssl in frontend.ssl %} crt {{ ssl.crt }}{% endfor %}{% endif %}
 
   mode {{ frontend.mode }}
 


### PR DESCRIPTION
https://github.com/Oefenweb/ansible-haproxy/commit/c0e4489704edad381033e153db9918d9933309cb removed the conditional check, but also removed the `ssl.cert` component which actually outputs the value

Causes an error when used
